### PR TITLE
Fix order in dist/package.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
   "deno.enable": true,
-  "deno.enablePaths": ["./bin", "./src", "./mod.ts"]
+  "deno.enablePaths": ["./bin", "./src", "./mod.ts"],
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "denoland.vscode-deno"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zipper-inc/client-js",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An easy way to interact with Zipper Applets from anywhere that supports ESM, CommonJS, or TypeScript.",
   "main": "./dist/script/index.js",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Including in a NextJS package yielded the following error:

```
Module not found: Default condition should be last one
```

Moving the `default` option under all entries of `"exports"` in `dist/package.json` made the error go away.

Updated the build script and added a miscellaneous fix for VSCode users.