### PR TITLE
Reduce shims to make sure we're mostly web compatible

### DIFF
--- a/bin/build.ts
+++ b/bin/build.ts
@@ -17,9 +17,15 @@ export async function build() {
   await buildNodePackage({
     entryPoints: [ENTRY_POINT],
     outDir: OUT_DIR,
+    /**
+     * Note
+     * Any shims must be both Node & Web compatible
+     */
     shims: {
-      deno: true,
-      undici: true,
+      deno: { test: true },
+    },
+    compilerOptions: {
+      lib: ['DOM', 'ES2021'],
     },
     package: {
       name,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zipper-inc/client-js",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "An easy way to interact with Zipper Applets from anywhere that supports ESM, CommonJS, or TypeScript.",
   "main": "./dist/script/src/index.js",
   "types": "./dist/types/src/index.d.ts",


### PR DESCRIPTION
By using default TypeScript fetch in Node, we don't need the shims. 

We're also not using Deno language features so we can turn that shim off and greatly reduce package size.