### PR TITLE
chore: add options to support local development

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -18,6 +18,8 @@ class Applet implements ZipperRunClient {
     this.baseUrl = getBaseUrlFromIndentifier(
       indentifier,
       options?.overrideHost,
+      options?.zipperRunUrl,
+      options?.prefeerHtps,
     );
     this.isDebugMode = !!options?.debug;
     if (options?.token) this.token = options.token;

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,7 +19,7 @@ class Applet implements ZipperRunClient {
       indentifier,
       options?.overrideHost,
       options?.zipperRunUrl,
-      options?.prefeerHtps,
+      options?.preferHtps,
     );
     this.isDebugMode = !!options?.debug;
     if (options?.token) this.token = options.token;

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,9 +17,7 @@ class Applet implements ZipperRunClient {
   constructor(indentifier: string, options?: AppletOptions) {
     this.baseUrl = getBaseUrlFromIndentifier(
       indentifier,
-      options?.overrideHost,
-      options?.zipperRunUrl,
-      options?.preferHtps,
+      options?.overrideZipperRunUrl,
     );
     this.isDebugMode = !!options?.debug;
     if (options?.token) this.token = options.token;

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,6 @@ export type Inputs = { [key: string]: Serializable | undefined };
 
 export type Output = Serializable | void;
 
-
 type Protocol = 'http' | 'https';
 type Port = number;
 /**
@@ -39,7 +38,9 @@ type Port = number;
 export type AppletOptions = {
   debug?: boolean;
   token?: string;
-  overrideZipperRunUrl?: `${Protocol}://${string}` | `${Protocol}://${string}:${Port}`;
+  overrideZipperRunUrl?:
+    | `${Protocol}://${string}`
+    | `${Protocol}://${string}:${Port}`;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export type AppletOptions = {
   overrideHost?: string;
   token?: string;
   zipperRunUrl?: string;
-  prefeerHtps?: boolean;
+  preferHtps?: boolean;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,15 +30,16 @@ export type Inputs = { [key: string]: Serializable | undefined };
 
 export type Output = Serializable | void;
 
+
+type Protocol = 'http' | 'https';
+type Port = number;
 /**
  * Passed in when creating an Applet
  */
 export type AppletOptions = {
   debug?: boolean;
-  overrideHost?: string;
   token?: string;
-  zipperRunUrl?: string;
-  preferHtps?: boolean;
+  overrideZipperRunUrl?: `${Protocol}://${string}` | `${Protocol}://${string}:${Port}`;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export type AppletOptions = {
   debug?: boolean;
   overrideHost?: string;
   token?: string;
+  zipperRunUrl?: string;
+  prefeerHtps?: boolean;
 };
 
 /**

--- a/src/url.test.ts
+++ b/src/url.test.ts
@@ -20,10 +20,34 @@ Deno.test(function respectsWholeUrl() {
   assertEquals(url, 'https://applet.zipper.host/');
 });
 
-Deno.test(function overridesWork() {
+Deno.test(function respectUrlWithPort() {
   const url = getBaseUrlFromIndentifier(
-    'zipper-client-test.zipper.run',
-    'zct.zpr.run',
+    'https://hello-world.localdev.me:3002',
   ).toString();
-  assertEquals(url, 'https://zct.zpr.run/');
+  assertEquals(url, 'https://hello-world.localdev.me:3002/');
+});
+
+Deno.test(function overrideZipperRunUrl() {
+  const url = getBaseUrlFromIndentifier(
+    'zipper-client-test',
+    'https://localdev.me:3002'
+  ).toString();
+  assertEquals(url, 'https://zipper-client-test.localdev.me:3002/');
+});
+
+Deno.test(function overrideWithoutPort() {
+  const url = getBaseUrlFromIndentifier(
+    'zipper-client-test',
+    'http://localdev.me'
+  ).toString();
+  assertEquals(url, 'http://zipper-client-test.localdev.me/');
+});
+
+
+Deno.test(function overrideFullUrl() {
+  const url = getBaseUrlFromIndentifier(
+    'https://zipper-client-test.zipper.run:3000/',
+    'http://localdev.me:8080'
+  ).toString();
+  assertEquals(url, 'http://zipper-client-test.localdev.me:8080/');
 });

--- a/src/url.test.ts
+++ b/src/url.test.ts
@@ -30,7 +30,7 @@ Deno.test(function respectUrlWithPort() {
 Deno.test(function overrideZipperRunUrl() {
   const url = getBaseUrlFromIndentifier(
     'zipper-client-test',
-    'https://localdev.me:3002'
+    'https://localdev.me:3002',
   ).toString();
   assertEquals(url, 'https://zipper-client-test.localdev.me:3002/');
 });
@@ -38,16 +38,15 @@ Deno.test(function overrideZipperRunUrl() {
 Deno.test(function overrideWithoutPort() {
   const url = getBaseUrlFromIndentifier(
     'zipper-client-test',
-    'http://localdev.me'
+    'http://localdev.me',
   ).toString();
   assertEquals(url, 'http://zipper-client-test.localdev.me/');
 });
 
-
 Deno.test(function overrideFullUrl() {
   const url = getBaseUrlFromIndentifier(
     'https://zipper-client-test.zipper.run:3000/',
-    'http://localdev.me:8080'
+    'http://localdev.me:8080',
   ).toString();
   assertEquals(url, 'http://zipper-client-test.localdev.me:8080/');
 });

--- a/src/url.ts
+++ b/src/url.ts
@@ -4,7 +4,7 @@ export function getBaseUrlFromIndentifier(
   identifier: string,
   overrideHost?: string,
   zipperRunUrl = DEFAULT_ZIPPER_DOT_RUN_HOST,
-  prefeerHtps = true,
+  preferHtps = true,
 ) {
   let url;
 
@@ -14,7 +14,7 @@ export function getBaseUrlFromIndentifier(
     // Remove anything that looks like a port temporarily since it confuses the URL parser
     url = new URL(identifier.replace(/:[0-9]+$/, ``));
   } catch (_e) {
-    const protocol = prefeerHtps ? "https" : 'http';
+    const protocol = preferHtps ? "https" : 'http';
     // If it looks like a host, add a protocol, other let's assume it's a slug
     url = /\.|:/.test(identifier)
       ? new URL(`${protocol}://${identifier}`)

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,27 +1,50 @@
 import { DEFAULT_ZIPPER_DOT_RUN_HOST } from './constants.ts';
+import { AppletOptions } from './index.ts';
 
 export function getBaseUrlFromIndentifier(
   identifier: string,
-  overrideHost?: string,
-  zipperRunUrl = DEFAULT_ZIPPER_DOT_RUN_HOST,
-  preferHtps = true,
+  overrideZipperRunUrl?: AppletOptions['overrideZipperRunUrl'],
 ) {
-  let url;
+  let url: URL | undefined;
+  let port;
 
   // If the identifier is a URL, we have what we need
   // Note: If the URL is not a zipper.run applet, it will def fail
   try {
     // Remove anything that looks like a port temporarily since it confuses the URL parser
-    url = new URL(identifier.replace(/:[0-9]+$/, ``));
+    // We'll add it back later
+    const portMatch = identifier.match(/:[0-9]+$/);
+    if (portMatch) {
+      port = portMatch[0];
+      identifier = identifier.replace(port, '');
+    }
+
+    url = new URL(identifier);
+    
+    // In this case, identifier is a full URL
+    if (overrideZipperRunUrl) {
+      const override = new URL(overrideZipperRunUrl);
+      const subdomain = url.host.split('.')[0];
+      const newUrl = new URL(`${override.protocol}//${subdomain}.${override.host}`);
+      // Here, we gonna use the port from the override
+      return newUrl
+    }
+    
+    return new URL(`${url.origin}${port || ''}`);
   } catch (_e) {
-    const protocol = preferHtps ? "https" : 'http';
-    // If it looks like a host, add a protocol, other let's assume it's a slug
+    // Identifier is not a URL, but if it looks like a host, we can add a protocol, other let's assume it's a slug
     url = /\.|:/.test(identifier)
-      ? new URL(`${protocol}://${identifier}`)
-      : new URL(`${protocol}://${identifier}.${zipperRunUrl}`);
+    ? new URL(`https://${identifier}`)
+    : new URL(`https://${identifier}.${DEFAULT_ZIPPER_DOT_RUN_HOST}`);
   }
 
-  if (overrideHost) url.host = overrideHost;
+  // If we have an override, we need to use it, the identifier itself is our subdomain
+  if (overrideZipperRunUrl) {
+    const override = new URL(overrideZipperRunUrl);
+    url = new URL(`${override.protocol}//${identifier}.${override.host}`);
+    // Here, we gonna use the port from the override
+    return new URL(url.origin);
+  }
 
-  return new URL(url.origin);
+  return new URL(`${url.origin}${port || ''}`);
 }

--- a/src/url.ts
+++ b/src/url.ts
@@ -3,6 +3,8 @@ import { DEFAULT_ZIPPER_DOT_RUN_HOST } from './constants.ts';
 export function getBaseUrlFromIndentifier(
   identifier: string,
   overrideHost?: string,
+  zipperRunUrl = DEFAULT_ZIPPER_DOT_RUN_HOST,
+  prefeerHtps = true,
 ) {
   let url;
 
@@ -12,10 +14,11 @@ export function getBaseUrlFromIndentifier(
     // Remove anything that looks like a port temporarily since it confuses the URL parser
     url = new URL(identifier.replace(/:[0-9]+$/, ``));
   } catch (_e) {
+    const protocol = prefeerHtps ? "https" : 'http';
     // If it looks like a host, add a protocol, other let's assume it's a slug
     url = /\.|:/.test(identifier)
-      ? new URL(`https://${identifier}`)
-      : new URL(`https://${identifier}.${DEFAULT_ZIPPER_DOT_RUN_HOST}`);
+      ? new URL(`${protocol}://${identifier}`)
+      : new URL(`${protocol}://${identifier}.${zipperRunUrl}`);
   }
 
   if (overrideHost) url.host = overrideHost;

--- a/src/url.ts
+++ b/src/url.ts
@@ -20,22 +20,24 @@ export function getBaseUrlFromIndentifier(
     }
 
     url = new URL(identifier);
-    
+
     // In this case, identifier is a full URL
     if (overrideZipperRunUrl) {
       const override = new URL(overrideZipperRunUrl);
       const subdomain = url.host.split('.')[0];
-      const newUrl = new URL(`${override.protocol}//${subdomain}.${override.host}`);
+      const newUrl = new URL(
+        `${override.protocol}//${subdomain}.${override.host}`,
+      );
       // Here, we gonna use the port from the override
-      return newUrl
+      return newUrl;
     }
-    
+
     return new URL(`${url.origin}${port || ''}`);
   } catch (_e) {
     // Identifier is not a URL, but if it looks like a host, we can add a protocol, other let's assume it's a slug
     url = /\.|:/.test(identifier)
-    ? new URL(`https://${identifier}`)
-    : new URL(`https://${identifier}.${DEFAULT_ZIPPER_DOT_RUN_HOST}`);
+      ? new URL(`https://${identifier}`)
+      : new URL(`https://${identifier}.${DEFAULT_ZIPPER_DOT_RUN_HOST}`);
   }
 
   // If we have an override, we need to use it, the identifier itself is our subdomain


### PR DESCRIPTION
This PR give us control above the applet URL, this way we can point it to local development, instead of always calling zipper.run